### PR TITLE
[CLEANUP] removes superfluous call to loadBaseTca

### DIFF
--- a/Classes/Service/AuthUser.php
+++ b/Classes/Service/AuthUser.php
@@ -76,7 +76,6 @@ class AuthUser extends AuthenticationService
      */
     public function init()
     {
-        ExtensionManagementUtility::loadBaseTca(false);
         if (!isset($GLOBALS['TSFE']) || empty($GLOBALS['TSFE']->sys_page)) {
             $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
         }


### PR DESCRIPTION
From the comment of ExtensionManagementUtility::loadBaseTca:
"This is an internal method of ExtensionManagementUtility. It is only used during bootstrap and extensions should not use it!"

The call is needless as ExtensionManagementUtility::loadBaseTca has been already executed and should not be executed twice. This leads also to some warning log entries in TYPO3 8.7. like "[WARNING] component="TYPO3.CMS.Core.Utility.ExtensionManagementUtility": TYPO3\CMS\Core\Category\CategoryRegistry: no category registered for table "tt_content". Key was already registered." on every frontend user login.

The extension still works as expected after this call is removed.