### PR TITLE
[BUGFIX] Fix broken TYPO3 v9 support

### DIFF
--- a/Classes/Domain/Service/RestrictionService.php
+++ b/Classes/Domain/Service/RestrictionService.php
@@ -298,7 +298,7 @@ class RestrictionService
     public function getEntry()
     {
         if (false === isset($this->entry)) {
-            $entry = $this->entryRepository->findByIdentifier($this->getClientIdentifier());
+            $entry = $this->entryRepository->findOneByIdentifier($this->getClientIdentifier());
             if ($entry instanceof Entry) {
                 $this->entry = $entry;
                 if ($this->isOutdated($entry)) {

--- a/Tests/Functional/Domain/Service/RestrictionServiceClientIpAbstract.php
+++ b/Tests/Functional/Domain/Service/RestrictionServiceClientIpAbstract.php
@@ -122,13 +122,13 @@ class RestrictionServiceClientIpAbstract extends FunctionalTestCase
         $this->configuration->expects($this->any())->method('getMaximumNumberOfFailures')->will($this->returnValue(10));
         $this->configuration->expects($this->any())->method('getResetTime')->will($this->returnValue(300));
         $this->configuration->expects($this->any())->method('getRestrictionTime')->will($this->returnValue(3000));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
 
         $entry = $this->getMockBuilder('Aoe\FeloginBruteforceProtection\Domain\Model\Entry')->getMock();
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(0));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 200));
 
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
 
@@ -147,8 +147,8 @@ class RestrictionServiceClientIpAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(10));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 400));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertTrue($this->restriction->isClientRestricted());
@@ -167,8 +167,8 @@ class RestrictionServiceClientIpAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(10));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 200));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 4000));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertFalse($this->restriction->isClientRestricted());
@@ -187,8 +187,8 @@ class RestrictionServiceClientIpAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(5));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 400));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertFalse($this->restriction->isClientRestricted());

--- a/Tests/Functional/Domain/Service/RestrictionServiceFrontendNameAbstract.php
+++ b/Tests/Functional/Domain/Service/RestrictionServiceFrontendNameAbstract.php
@@ -120,12 +120,12 @@ class RestrictionServiceFrontendNameAbstract extends FunctionalTestCase
         $this->configuration->expects($this->any())->method('getResetTime')->will($this->returnValue(300));
         $this->configuration->expects($this->any())->method('getRestrictionTime')->will($this->returnValue(3000));
 
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
 
         $entry = $this->getMockBuilder('Aoe\FeloginBruteforceProtection\Domain\Model\Entry')->getMock();
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(0));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
 
@@ -144,8 +144,8 @@ class RestrictionServiceFrontendNameAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(10));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 400));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertTrue($this->restriction->isClientRestricted());
@@ -163,8 +163,8 @@ class RestrictionServiceFrontendNameAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(10));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 4000));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertFalse($this->restriction->isClientRestricted());
@@ -182,8 +182,8 @@ class RestrictionServiceFrontendNameAbstract extends FunctionalTestCase
         $entry->expects($this->any())->method('getFailures')->will($this->returnValue(5));
         $entry->expects($this->any())->method('getCrdate')->will($this->returnValue(time() - 400));
         $entry->expects($this->any())->method('getTstamp')->will($this->returnValue(time() - 400));
-        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findByIdentifier', 'remove'], [], '', false);
-        $entryRepository->expects($this->any())->method('findByIdentifier')->will($this->returnValue($entry));
+        $entryRepository = $this->getAccessibleMock(EntryRepository::class, ['findOneByIdentifier', 'remove'], [], '', false);
+        $entryRepository->expects($this->any())->method('findOneByIdentifier')->will($this->returnValue($entry));
         $this->inject($this->restriction, 'entryRepository', $entryRepository);
         $this->inject($this->restriction, 'configuration', $this->configuration);
         $this->assertFalse($this->restriction->isClientRestricted());


### PR DESCRIPTION
TYPO3 v9 needs the 2.1.2 commits from @TomSchenk for it to function.

I'd prefer to re-add TYPO3 v9 support on top of 2.1.2, but I'm not entirely sure why commit 4d9a09e removed it, so I'll leave that consideration up to you.