### PR TITLE
[TASK] remove deprected field loginFailure and add postProcessing hoo…

### DIFF
--- a/Classes/Hooks/UserAuth/PostUserLookUp.php
+++ b/Classes/Hooks/UserAuth/PostUserLookUp.php
@@ -79,7 +79,6 @@ class PostUserLookUp
 
         // Continue only if the protection is enabled
         if ($this->getConfiguration()->isEnabled()) {
-            /** @var RestrictionIdentifierFabric $restrictionIdentifierFabric */
             $restrictionIdentifierFabric = $this->getRestrictionIdentifierFabric();
             $this->restrictionIdentifier = $restrictionIdentifierFabric->getRestrictionIdentifier(
                 $this->getConfiguration(),
@@ -87,15 +86,31 @@ class PostUserLookUp
             );
             $this->restrictionService = $this->initRestrictionService();
 
+            if ($this->restrictionIdentifier->checkPreconditions() && $this->hasFeUserLoggedIn($this->frontendUserAuthentication)) {
+                $this->restrictionService
+                    ->removeEntry();
+            }
+        }
+    }
+
+    /**
+     * @param array $params
+     */
+    public function processFailedLogin(&$params): void
+    {
+        // Continue only if the protection is enabled
+        if ($this->getConfiguration()->isEnabled()) {
+            $restrictionIdentifierFabric = $this->getRestrictionIdentifierFabric();
+            $this->restrictionIdentifier = $restrictionIdentifierFabric->getRestrictionIdentifier(
+                $this->getConfiguration(),
+                null
+            );
+            $this->restrictionService = $this->initRestrictionService();
+
             if ($this->restrictionIdentifier->checkPreconditions()) {
-                if ($this->hasFeUserLoggedIn($this->frontendUserAuthentication)) {
-                    $this->restrictionService
-                        ->removeEntry();
-                } elseif ($this->hasFeUserLogInFailed($this->frontendUserAuthentication)) {
-                    $this->restrictionService
-                        ->checkAndHandleRestriction();
-                    $this->updateGlobals();
-                }
+                $this->restrictionService
+                    ->checkAndHandleRestriction();
+                $this->updateGlobals();
             }
         }
     }
@@ -171,10 +186,5 @@ class PostUserLookUp
         return $userAuthObject->loginType === 'FE' &&
             is_array($userAuthObject->user) &&
             $userAuthObject->loginSessionStarted;
-    }
-
-    private function hasFeUserLogInFailed(AbstractUserAuthentication $userAuthObject): bool
-    {
-        return $userAuthObject->loginType === 'FE' && !$userAuthObject->user;
     }
 }

--- a/Classes/Hooks/UserAuth/PostUserLookUp.php
+++ b/Classes/Hooks/UserAuth/PostUserLookUp.php
@@ -170,7 +170,7 @@ class PostUserLookUp
         return true;
     }
 
-    private function getRestrictionMessage(): string
+    private function getRestrictionMessage(): ?string
     {
         $time = (int) ($this->getConfiguration()->getRestrictionTime() / 60);
 

--- a/code-quality/phpstan-baseline.neon
+++ b/code-quality/phpstan-baseline.neon
@@ -99,10 +99,6 @@ parameters:
 			count: 1
 			path: ../Classes/Hooks/UserAuth/PostUserLookUp.php
 		-
-			message: "#^Method Aoe\\\\FeloginBruteforceProtection\\\\Hooks\\\\UserAuth\\\\PostUserLookUp\\:\\:getRestrictionMessage\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: ../Classes/Hooks/UserAuth/PostUserLookUp.php
-		-
 			message: "#^Method Aoe\\\\FeloginBruteforceProtection\\\\Hooks\\\\UserAuth\\\\PostUserLookUp\\:\\:initRestrictionService\\(\\) should return Aoe\\\\FeloginBruteforceProtection\\\\Domain\\\\Service\\\\RestrictionService but returns object\\.$#"
 			count: 1
 			path: ../Classes/Hooks/UserAuth/PostUserLookUp.php

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,6 +5,7 @@ defined('TYPO3') or die();
 if (TYPO3_MODE == 'FE') {
     // postUserLookUp hookC
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp']['felogin_bruteforce_protection'] = \Aoe\FeloginBruteforceProtection\Hooks\UserAuth\PostUserLookUp::class . '->handlePostUserLookUp';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postLoginFailureProcessing']['felogin_bruteforce_protection'] = \Aoe\FeloginBruteforceProtection\Hooks\UserAuth\PostUserLookUp::class . '->processFailedLogin';
 }
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService(


### PR DESCRIPTION
…k for login failures

The following deprecation was removed and replaced with the postProcessingHook for login failures:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92989-AbstractUserAuthentication-loginFailureRemoved.html

